### PR TITLE
Store column and line numbers in serializable_fn metadata.

### DIFF
--- a/src/clj/serializable/fn.clj
+++ b/src/clj/serializable/fn.clj
@@ -21,12 +21,15 @@
 (defmacro ^{:doc (str (:doc (meta #'clojure.core/fn))
                       "\n\n  Oh, but it also allows serialization!!!111eleven")}
   fn [& sigs]
-  (let [[env-form namespace form] (save-env (vals &env) &form)]
+  (let [[env-form namespace source] (save-env (vals &env) &form)
+        form-meta (meta &form)]
     `(with-meta (clojure.core/fn ~@sigs)
        {:type ::serializable-fn
+        ::line (get ~form-meta :line)
+        ::column (get ~form-meta :column)
         ::env ~env-form
         ::namespace ~namespace
-        ::source ~form})))
+        ::source ~source})))
 
 (defn- try-parse-num [^String s]
   (try
@@ -182,4 +185,5 @@
                rest-meta)))
 
 (defmethod print-method ::serializable-fn [o ^Writer w]
-  (print-method (::source (meta o)) w))
+  (let [m (meta o)]
+    (print-method (str (::namespace m) ":" (::line m) ":" (::column m) " " (::source m))  w)))

--- a/src/clj/serializable/fn.clj
+++ b/src/clj/serializable/fn.clj
@@ -8,10 +8,26 @@
 (def ^:dynamic *serialize* #(Utils/serialize %))
 (def ^:dynamic *deserialize* #(Utils/deserialize %))
 
-(defn- save-env [bindings form]
-  (let [form (with-meta (cons `fn (rest form)) ; serializable/fn, not core/fn
-               (meta form))
+(defn- mangle-name [name]
+  (clojure.lang.Compiler/munge name))
+
+(defn- generate-function-name [line column form]
+  (let [first-param (first (rest form))
+        custom-fn-name? (not (vector? first-param))]
+        (if custom-fn-name?
+          nil
+          (symbol (mangle-name  (str *ns* "_sfn_" line \_ column))))))
+
+(defn- save-env [bindings form fn-name]
+  (let [
         namespace (str *ns*)
+        ; replace core/fn , with serializable/fn
+        ; give anonymous fn a name, so it will show up in stacktraces
+        form (with-meta (cons `fn (if fn-name
+                                    (cons  fn-name (rest form))
+                                    (rest form)
+                                    ))
+               (meta form))
         savers (for [^clojure.lang.Compiler$LocalBinding b bindings]
                  [(str (.sym b)) (.sym b)])
         env-form `(into {} ~(vec savers))]
@@ -21,12 +37,17 @@
 (defmacro ^{:doc (str (:doc (meta #'clojure.core/fn))
                       "\n\n  Oh, but it also allows serialization!!!111eleven")}
   fn [& sigs]
-  (let [[env-form namespace source] (save-env (vals &env) &form)
-        form-meta (meta &form)]
-    `(with-meta (clojure.core/fn ~@sigs)
+  (let [form-meta (meta &form)
+        line (get form-meta :line)
+        column (get form-meta :column)
+        fn-name (generate-function-name line column &form)
+        [env-form namespace source] (save-env (vals &env) &form fn-name)]
+    `(with-meta (clojure.core/fn ~@(if fn-name
+                                     (cons  fn-name sigs)
+                                     sigs))
        {:type ::serializable-fn
-        ::line (get ~form-meta :line)
-        ::column (get ~form-meta :column)
+        ::line ~line
+        ::column ~column
         ::env ~env-form
         ::namespace ~namespace
         ::source ~source})))

--- a/test/serializable/fn_test.clj
+++ b/test/serializable/fn_test.clj
@@ -15,17 +15,15 @@
   (is (= 2 (dinc 0))))
 
 (deftest metadata-fns-return-source
-  (is (= dinc-list (:serializable.fn/source (meta dinc)))))
+  (is (.contains (:serializable.fn/source (meta dinc))(pr-str dinc-list) )))
 
 (deftest printing-fns-show-source
-  (is (= (pr-str dinc-list)
-         (pr-str dinc))))
+    (is (.contains (pr-str dinc) (pr-str dinc-list))))
 
 (deftest preserve-reader-metadata
-  (is (number? (:line (meta (:serializable.fn/source
-                             (meta dinc)))))))
+  (is (number? (:serializable.fn/line (meta dinc)))))
 
-(def write+read (comp eval read-string pr-str))
+(def write+read (comp deserialize serialize))
 
 (defn round-trip [f & args]
   (apply (write+read f) args))

--- a/test/serializable/fn_test.clj
+++ b/test/serializable/fn_test.clj
@@ -15,10 +15,10 @@
   (is (= 2 (dinc 0))))
 
 (deftest metadata-fns-return-source
-  (is (.contains (:serializable.fn/source (meta dinc))(pr-str dinc-list) )))
+  (is (.contains (:serializable.fn/source (meta dinc))(str (first (drop 2 dinc-list))) )))
 
 (deftest printing-fns-show-source
-    (is (.contains (pr-str dinc) (pr-str dinc-list))))
+    (is (.contains (pr-str dinc) (str (first (drop 2 dinc-list))))))
 
 (deftest preserve-reader-metadata
   (is (number? (:serializable.fn/line (meta dinc)))))
@@ -30,6 +30,12 @@
 
 (deftest serializable-fn-roundtrip!!!111eleven
   (is (= 2 (round-trip dinc 0))))
+
+(deftest stacktraces-contain-line-col
+  (try ((fn []
+        (throw (RuntimeException.))))
+       (catch RuntimeException e
+         (is (re-matches #".*_test_sfn_\d{1,3}_\d{1,3}_.*" (str (first (.getStackTrace e))) )))))
 
 (deftest roundtrip-with-lexical-nonconst-context
   (let [x 10, y (inc x)]


### PR DESCRIPTION
Print those in print-method for debugging purposes.
Generate custom fn-name containing line and col number so that's visible in stacktraces.
Fix tests - they were broken for a while.
