### PR TITLE
Update to support JDK-17 and Scala-2.12

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,19 +1,19 @@
-(defproject yieldbot/serializable-fn "0.1.2"
+(defproject yieldbot/serializable-fn "0.1.3"
   :url "http://github.com/sorenmacbeth/serializable-fn"
   :description "Serializable functions in Clojure"
   :min-lein-version "2.0.0"
   :source-paths ["src/clj"]
   :java-source-paths ["src/jvm"]
-  :javac-options ["-source" "1.6" "-target" "1.6"]
   :jvm-opts ^:replace ["-server" "-Xmx512m"]
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/tools.logging "0.3.1"]
-                 [com.twitter/chill-java "0.8.0"]
+  :dependencies [[org.clojure/clojure "1.12.0"]
+                 [org.clojure/tools.logging "1.3.0"]
+                 [com.esotericsoftware/kryo "5.6.1"]
+                 [com.twitter/chill-java "0.10.0"]
                  [com.twitter/carbonite "1.5.0"]]
   :profiles {:dev
-             {:dependencies [[ch.qos.logback/logback-classic "1.1.2"]
-                             [criterium "0.4.3"]]}
+             {:dependencies [[ch.qos.logback/logback-classic "1.5.18"]
+                             [criterium "0.4.6"]]}
              :provided
-             {:dependencies [[ch.qos.logback/logback-classic "1.1.2"]]}})
+             {:dependencies [[ch.qos.logback/logback-classic "1.5.18"]]}})


### PR DESCRIPTION
Update to support `JDK-17` & `Scala-2.12`

Changes Proposed:
- Update in minor version of the project
- Upgrade Clojure to latest 1.12.0
- Upgrade Tools logging to support latest Clojure version
- Upgrade Kryo library to support JDK-17
- Upgrade Chill Java to support JDK-17 & Scala-2.12
- Remove javac options